### PR TITLE
Improve SQL connection robustness

### DIFF
--- a/DataAccess/Concrete/Contexts/IBKSContext.cs
+++ b/DataAccess/Concrete/Contexts/IBKSContext.cs
@@ -13,7 +13,24 @@ namespace DataAccess.Concrete.Contexts
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            optionsBuilder.UseSqlServer(@"Server=254-135-044-33\SQLEXPRESS;Database=IBKSContext;Trusted_Connection=True;TrustServerCertificate=True;MultipleActiveResultSets=true");
+            if (!optionsBuilder.IsConfigured)
+            {
+                var server = $"{Environment.UserName}\\SQLEXPRESS";
+                var connectionString =
+                    $"Server={server};Database=IBKSContext;Trusted_Connection=True;TrustServerCertificate=True;MultipleActiveResultSets=true";
+
+                try
+                {
+                    optionsBuilder.UseSqlServer(connectionString);
+
+                    using var connection = new Microsoft.Data.SqlClient.SqlConnection(connectionString);
+                    connection.Open();
+                }
+                catch
+                {
+                    // Silently handle connection errors so application can continue
+                }
+            }
         }
 
         public DbSet<Api> Apis { get; set; }

--- a/ibks/Program.cs
+++ b/ibks/Program.cs
@@ -2,6 +2,8 @@ using Autofac;
 using Autofac.Extensions.DependencyInjection;
 using Business.DependencyResolvers.Autofac;
 using DataAccess.Concrete.Contexts;
+using Microsoft.EntityFrameworkCore;
+using System.Windows.Forms;
 using ibks.DependencyResolvers.Autofac;
 using ibks.Forms;
 using Microsoft.AspNetCore.Authentication;
@@ -35,6 +37,18 @@ namespace ibks
 
                     var context = scope.ServiceProvider.GetRequiredService<IBKSContext>();
 
+                    try
+                    {
+                        if (!context.Database.CanConnect())
+                        {
+                            MessageBox.Show("Veritabanına bağlanılamadı.", "Uyarı", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show($"Veritabanına bağlanırken hata: {ex.Message}", "Uyarı", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    }
+
                     //context.Database.Migrate();
 
                     //context.Database.EnsureCreated();
@@ -46,7 +60,7 @@ namespace ibks
             }
             else
             {
-                MessageBox.Show("Uygulama zaten �al���yor.", "Hata", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MessageBox.Show("Uygulama zaten çalýþýyor.", "Hata", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 }
         public static IHostBuilder CreateHostBuilder(string[] args) =>


### PR DESCRIPTION
## Summary
- set SQL connection string dynamically based on the logged in user and catch connection errors
- warn at startup when database cannot be reached

## Testing
- `dotnet restore`
- `dotnet build ibks.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877437eed5c8324846ca6848cf3ccbd