### PR TITLE
Notify user on database or API connection failures

### DIFF
--- a/DataAccess/Concrete/Contexts/IBKSContext.cs
+++ b/DataAccess/Concrete/Contexts/IBKSContext.cs
@@ -3,6 +3,7 @@ using Entities.Concrete;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using System;
+using System.Windows.Forms;
 
 namespace DataAccess.Concrete.Contexts
 {
@@ -28,9 +29,9 @@ namespace DataAccess.Concrete.Contexts
                     using var connection = new Microsoft.Data.SqlClient.SqlConnection(connectionString);
                     connection.Open();
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // hata olursa sessizce geç
+                    MessageBox.Show($"Veritabanına bağlanılamadı: {ex.Message}", "Bağlantı Hatası", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                 }
             }
         }

--- a/DataAccess/DataAccess.csproj
+++ b/DataAccess/DataAccess.csproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>net8.0-windows7.0</TargetFramework>
+          <TargetFramework>net8.0-windows7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ibks/Forms/Pages/HomePage.cs
+++ b/ibks/Forms/Pages/HomePage.cs
@@ -8,6 +8,7 @@ using PLC;
 using PLC.Sharp7.Helpers;
 using PLC.Sharp7.Services;
 using System.ComponentModel;
+using System.Windows.Forms;
 using WebAPI.Abstract;
 
 namespace ibks.Forms.Pages
@@ -75,6 +76,7 @@ namespace ibks.Forms.Pages
                     else
                     {
                         data.Data.IsSent = false;
+                        MessageBox.Show(res.Message, "API Bağlantı Hatası", MessageBoxButtons.OK, MessageBoxIcon.Warning);
                     }
 
                     _sendDataManager.Add(data.Data);
@@ -171,6 +173,11 @@ namespace ibks.Forms.Pages
             foreach (var item in missedData.Data)
             {
                 var res = await _sendDataController.SendData(item);
+
+                if (!res.Success)
+                {
+                    MessageBox.Show(res.Message, "API Bağlantı Hatası", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                }
 
                 item.IsSent = res.Success;
 


### PR DESCRIPTION
## Summary
- Warn users with a MessageBox if the database connection cannot be opened
- Enable Windows Forms in data access layer to support UI notifications
- Show MessageBox warnings when API data sends fail, allowing the app to continue running

## Testing
- `dotnet build -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b802997f9c83248d35108ebc958be4