### PR TITLE
Replace report type radio buttons with combo box

### DIFF
--- a/ibks/Forms/Pages/ReportingPage.Designer.cs
+++ b/ibks/Forms/Pages/ReportingPage.Designer.cs
@@ -35,10 +35,7 @@
             tableLayoutPanel2 = new TableLayoutPanel();
             tableLayoutPanel3 = new TableLayoutPanel();
             GroupBoxReportTypes = new GroupBox();
-            RadioButtonLogData = new RadioButton();
-            RadioButtonSampleData = new RadioButton();
-            RadioButtonCalibrationData = new RadioButton();
-            RadioButtonInstantData = new RadioButton();
+            ComboBoxReportType = new ComboBox();
             groupBox3 = new GroupBox();
             RadioButtonSortByLast = new RadioButton();
             RadioButtonSortByFirst = new RadioButton();
@@ -150,10 +147,7 @@
             // 
             // GroupBoxReportTypes
             // 
-            GroupBoxReportTypes.Controls.Add(RadioButtonLogData);
-            GroupBoxReportTypes.Controls.Add(RadioButtonSampleData);
-            GroupBoxReportTypes.Controls.Add(RadioButtonCalibrationData);
-            GroupBoxReportTypes.Controls.Add(RadioButtonInstantData);
+            GroupBoxReportTypes.Controls.Add(ComboBoxReportType);
             GroupBoxReportTypes.Dock = DockStyle.Fill;
             GroupBoxReportTypes.Font = new Font("Arial", 9F, FontStyle.Bold, GraphicsUnit.Point);
             GroupBoxReportTypes.Location = new Point(6, 6);
@@ -162,50 +156,17 @@
             GroupBoxReportTypes.TabIndex = 5;
             GroupBoxReportTypes.TabStop = false;
             GroupBoxReportTypes.Text = "RAPOR TİPİ";
-            // 
-            // RadioButtonLogData
-            // 
-            RadioButtonLogData.AutoSize = true;
-            RadioButtonLogData.Location = new Point(6, 47);
-            RadioButtonLogData.Name = "RadioButtonLogData";
-            RadioButtonLogData.Size = new Size(53, 19);
-            RadioButtonLogData.TabIndex = 2;
-            RadioButtonLogData.TabStop = true;
-            RadioButtonLogData.Text = "Kayıt";
-            RadioButtonLogData.UseVisualStyleBackColor = true;
-            // 
-            // RadioButtonSampleData
-            // 
-            RadioButtonSampleData.AutoSize = true;
-            RadioButtonSampleData.Location = new Point(88, 47);
-            RadioButtonSampleData.Name = "RadioButtonSampleData";
-            RadioButtonSampleData.Size = new Size(72, 19);
-            RadioButtonSampleData.TabIndex = 2;
-            RadioButtonSampleData.TabStop = true;
-            RadioButtonSampleData.Text = "Numune";
-            RadioButtonSampleData.UseVisualStyleBackColor = true;
-            // 
-            // RadioButtonCalibrationData
-            // 
-            RadioButtonCalibrationData.AutoSize = true;
-            RadioButtonCalibrationData.Location = new Point(88, 22);
-            RadioButtonCalibrationData.Name = "RadioButtonCalibrationData";
-            RadioButtonCalibrationData.Size = new Size(92, 19);
-            RadioButtonCalibrationData.TabIndex = 2;
-            RadioButtonCalibrationData.TabStop = true;
-            RadioButtonCalibrationData.Text = "Kalibrasyon";
-            RadioButtonCalibrationData.UseVisualStyleBackColor = true;
-            // 
-            // RadioButtonInstantData
-            // 
-            RadioButtonInstantData.AutoSize = true;
-            RadioButtonInstantData.Location = new Point(6, 22);
-            RadioButtonInstantData.Name = "RadioButtonInstantData";
-            RadioButtonInstantData.Size = new Size(62, 19);
-            RadioButtonInstantData.TabIndex = 2;
-            RadioButtonInstantData.TabStop = true;
-            RadioButtonInstantData.Text = "Ölçüm";
-            RadioButtonInstantData.UseVisualStyleBackColor = true;
+            //
+            // ComboBoxReportType
+            //
+            ComboBoxReportType.Dock = DockStyle.Top;
+            ComboBoxReportType.DropDownStyle = ComboBoxStyle.DropDownList;
+            ComboBoxReportType.FormattingEnabled = true;
+            ComboBoxReportType.Items.AddRange(new object[] { "Ölçüm", "Kalibrasyon", "Numune", "Kayıt" });
+            ComboBoxReportType.Location = new Point(3, 19);
+            ComboBoxReportType.Name = "ComboBoxReportType";
+            ComboBoxReportType.Size = new Size(194, 23);
+            ComboBoxReportType.TabIndex = 0;
             // 
             // groupBox3
             // 
@@ -543,15 +504,12 @@
         private RadioButton RadioButtonSortByFirst;
         private RadioButton RadioButtonSortByLast;
         private GroupBox GroupBoxReportTypes;
-        private RadioButton RadioButtonLogData;
-        private RadioButton RadioButtonCalibrationData;
-        private RadioButton RadioButtonInstantData;
+        private ComboBox ComboBoxReportType;
         private TableLayoutPanel tableLayoutPanel4;
         private DataGridView DataGridViewDatas;
         private TableLayoutPanel tableLayoutPanel5;
         private TableLayoutPanel tableLayoutPanel6;
         private Button ButtonSaveAsPdf;
         private Button ButtonSaveAsExcel;
-        private RadioButton RadioButtonSampleData;
     }
 }

--- a/ibks/Forms/Pages/ReportingPage.cs
+++ b/ibks/Forms/Pages/ReportingPage.cs
@@ -30,45 +30,46 @@ namespace ibks.Forms.Pages
 
         private void ButtonGenerate_Click(object sender, EventArgs e)
         {
-            var checkedRadioButton = GroupBoxReportTypes.Controls.OfType<RadioButton>()
-                           .FirstOrDefault(n => n.Checked);
+            var selectedReportType = ComboBoxReportType.SelectedItem?.ToString();
 
-            if (checkedRadioButton != null)
+            if (string.IsNullOrWhiteSpace(selectedReportType))
             {
-                if (checkedRadioButton == RadioButtonInstantData)
-                {
-                    var data = _sendDataManager.GetAll(
-                        d => d.Readtime > _dateFilterStart && d.Readtime < _dateFilterEnd).Data;
+                return;
+            }
 
-                    DataGridViewDatas.DataSource = RadioButtonSortByFirst.Checked ? data
-                        : data.OrderByDescending(d => d.Readtime).ToList();
+            if (selectedReportType == "Ölçüm")
+            {
+                var data = _sendDataManager.GetAll(
+                    d => d.Readtime > _dateFilterStart && d.Readtime < _dateFilterEnd).Data;
 
-                    DataGridViewCustomization("InstantData");
-                }
-                else if (checkedRadioButton == RadioButtonCalibrationData)
-                {
-                    var data = _calibrationManager.GetAll(
-                        d => d.TimeStamp > DateTimePickerFirstDate.Value && d.TimeStamp < DateTimePickerLastDate.Value).Data;
+                DataGridViewDatas.DataSource = RadioButtonSortByFirst.Checked ? data
+                    : data.OrderByDescending(d => d.Readtime).ToList();
 
-                    DataGridViewDatas.DataSource = RadioButtonSortByFirst.Checked ? data
-                        : data.OrderByDescending(d => d.TimeStamp).ToList();
+                DataGridViewCustomization("InstantData");
+            }
+            else if (selectedReportType == "Kalibrasyon")
+            {
+                var data = _calibrationManager.GetAll(
+                    d => d.TimeStamp > DateTimePickerFirstDate.Value && d.TimeStamp < DateTimePickerLastDate.Value).Data;
 
-                    DataGridViewCustomization("CalibrationData");
-                }
-                else if (checkedRadioButton == RadioButtonSampleData)
-                {
-                    var data = _sampleManager.GetAll(
-                        d => d.DateTime > DateTimePickerFirstDate.Value && d.DateTime < DateTimePickerLastDate.Value).Data;
+                DataGridViewDatas.DataSource = RadioButtonSortByFirst.Checked ? data
+                    : data.OrderByDescending(d => d.TimeStamp).ToList();
 
-                    DataGridViewDatas.DataSource = RadioButtonSortByFirst.Checked ? data
-                        : data.OrderByDescending(d => d.DateTime).ToList();
+                DataGridViewCustomization("CalibrationData");
+            }
+            else if (selectedReportType == "Numune")
+            {
+                var data = _sampleManager.GetAll(
+                    d => d.DateTime > DateTimePickerFirstDate.Value && d.DateTime < DateTimePickerLastDate.Value).Data;
 
-                    DataGridViewCustomization("SampleData");
-                }
-                else
-                {
-                    //TODO
-                }
+                DataGridViewDatas.DataSource = RadioButtonSortByFirst.Checked ? data
+                    : data.OrderByDescending(d => d.DateTime).ToList();
+
+                DataGridViewCustomization("SampleData");
+            }
+            else
+            {
+                DataGridViewDatas.DataSource = null;
             }
 
             DataGridViewDatas.Refresh();
@@ -76,7 +77,7 @@ namespace ibks.Forms.Pages
 
         private void ReportingPage_Load(object sender, EventArgs e)
         {
-            RadioButtonInstantData.Checked = true;
+            ComboBoxReportType.SelectedIndex = ComboBoxReportType.Items.Count > 0 ? 0 : -1;
             RadioButtonDaily.Checked = true;
             RadioButtonSortByFirst.Checked = true;
 


### PR DESCRIPTION
## Summary
- replace the reporting page's measurement type radio buttons with a drop-down combobox
- update report generation logic to work with the new combobox selection while keeping existing sorting behaviour

## Testing
- not run (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cd363cbf848324bf0a178876ee63aa