### PR TITLE
Add data validity reporting to WinForms reporting page

### DIFF
--- a/ibks/Forms/Pages/ReportingPage.Designer.cs
+++ b/ibks/Forms/Pages/ReportingPage.Designer.cs
@@ -162,7 +162,7 @@
             ComboBoxReportType.Dock = DockStyle.Top;
             ComboBoxReportType.DropDownStyle = ComboBoxStyle.DropDownList;
             ComboBoxReportType.FormattingEnabled = true;
-            ComboBoxReportType.Items.AddRange(new object[] { "Ölçüm", "Kalibrasyon", "Numune", "Kayıt" });
+            ComboBoxReportType.Items.AddRange(new object[] { "Ölçüm", "Kalibrasyon", "Numune", "Kayıt", "Veri Geçerlilik Durumu" });
             ComboBoxReportType.Location = new Point(3, 19);
             ComboBoxReportType.Name = "ComboBoxReportType";
             ComboBoxReportType.Size = new Size(194, 23);


### PR DESCRIPTION
## Summary
- add the new "Veri Geçerlilik Durumu" option to the reporting combo box
- implement daily and monthly validity calculations for SendData records, including wash-sequence checks and tolerance thresholds
- surface the calculated validity metrics, statuses and summaries within the reporting grid

## Testing
- dotnet build ibks.sln *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3c9e22508324a545a14c6c272b72